### PR TITLE
Allow callers to wait for ExecCtx to stop

### DIFF
--- a/monitor/exec_arm.go
+++ b/monitor/exec_arm.go
@@ -128,6 +128,8 @@ type ExecCtx struct {
 
 	// execution state
 	run bool
+	// stopped will be closed once the context has stopped running.
+	stopped chan struct{}
 	// TrustZone configuration
 	ns bool
 	// executing g stack pointer
@@ -197,6 +199,8 @@ func (ctx *ExecCtx) schedule() (err error) {
 // exception, or any other error, is raised.
 func (ctx *ExecCtx) Run() (err error) {
 	ctx.run = true
+	ctx.stopped = make(chan struct{})
+	defer close(ctx.stopped)
 
 	for ctx.run {
 		if err = ctx.schedule(); err != nil {
@@ -223,11 +227,13 @@ func (ctx *ExecCtx) Run() (err error) {
 }
 
 // Stop stops the execution context.
-func (ctx *ExecCtx) Stop() {
+// Returns a channel which will become closed once the context ceases to run.
+func (ctx *ExecCtx) Stop() chan struct{} {
 	mux.Lock()
 	defer mux.Unlock()
 
 	ctx.run = false
+	return ctx.stopped
 }
 
 // Load returns an execution context initialized for the argument entry point

--- a/monitor/exec_arm.go
+++ b/monitor/exec_arm.go
@@ -227,12 +227,15 @@ func (ctx *ExecCtx) Run() (err error) {
 }
 
 // Stop stops the execution context.
-// Returns a channel which will become closed once the context ceases to run.
-func (ctx *ExecCtx) Stop() chan struct{} {
+func (ctx *ExecCtx) Stop() {
 	mux.Lock()
 	defer mux.Unlock()
 
 	ctx.run = false
+}
+
+// Done returns a channel which will be closed once execution context has stopped.
+func (ctx *ExecCtx) Done() chan struct{} {
 	return ctx.stopped
 }
 

--- a/monitor/exec_riscv64.go
+++ b/monitor/exec_riscv64.go
@@ -226,12 +226,15 @@ func (ctx *ExecCtx) Run() (err error) {
 }
 
 // Stop stops the execution context.
-// Returns a channel which will become closed once the context ceases to run.
-func (ctx *ExecCtx) Stop() chan struct{} {
+func (ctx *ExecCtx) Stop() {
 	mux.Lock()
 	defer mux.Unlock()
 
 	ctx.run = false
+}
+
+// Done returns a channel which will be closed once execution context has stopped.
+func (ctx *ExecCtx) Done() chan struct{} {
 	return ctx.stopped
 }
 


### PR DESCRIPTION
This PR adds a mechanism to optionally allow calls to wait for `ExecCtx` to fully stopped after a call to `Stop()`.

The channel returned by `Stop` will be closed once the `Run` func exits, so callers wanting to block for this can update their call site to `<-eCtx.Stop()`.

This seems to be important when the caller is "restarting" an applet, e.g. after a config change, as there appears to be a race which adversely affects subsequent applet operation:

```
00:02:48 SM received configuration update, restarting applet
00:02:48 SM applet loaded addr:0x90000000 entry:0x9007d480 size:21806089
00:02:48 SM applet started mode:USR sp:0xa0000000 pc:0x9007d480 ns:false
00:02:48 SM applet stopped mode:USR sp:0x9ffffdec lr:0x90580e28 pc:0x90580e28 ns:false err:<nil>
```

In the above scenario, networking was no longer functioning after the restart.

Updating to block on `<-Stop()` allowed repeated applet restarts with no ill effect on networking at least.

